### PR TITLE
row: fix for 64-bit int

### DIFF
--- a/mysql/row.go
+++ b/mysql/row.go
@@ -52,7 +52,7 @@ func (tr Row) Str(nn int) (str string) {
 	return
 }
 
-const _MAX_INT = int(^uint(0) >> 1)
+const _MAX_INT = int32(^uint32(0) >> 1)
 const _MIN_INT = -_MAX_INT - 1
 
 // Get the nn-th value and return it as int (0 if NULL). Return error if
@@ -114,7 +114,7 @@ func (tr Row) ForceInt(nn int) (val int) {
 	return
 }
 
-const _MAX_UINT = ^uint(0)
+const _MAX_UINT = ^uint32(0)
 
 // Get the nn-th value and return it as uint (0 if NULL). Return error if
 // conversion is impossible.


### PR DESCRIPTION
a recent commit to to default branch of go makes int 64-bit on 64-bit
machines. _MAX_INT and _MAX_UINT calculations need to be updated to
account for this.
