### PR TITLE
Add the default mysql port when not specified

### DIFF
--- a/native/mysql.go
+++ b/native/mysql.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"reflect"
+	"strings"
 )
 
 type serverInfo struct {
@@ -70,7 +71,18 @@ func New(proto, laddr, raddr, user, passwd string, db ...string) mysql.Conn {
 	} else if len(db) > 1 {
 		panic("mymy.New: too many arguments")
 	}
+
+	// set default port if not specified for tcp.
+	if strings.Index(my.proto, "tcp") > -1 {
+		defaultPort(&my.raddr)
+	}
 	return &my
+}
+
+func defaultPort(addr *string) {
+	if _, _, err := net.SplitHostPort(*addr); err != nil {
+		*addr = net.JoinHostPort(*addr, "3306")
+	}
 }
 
 // Creates new (not connected) connection using configuration from current

--- a/native/native_test.go
+++ b/native/native_test.go
@@ -1180,3 +1180,9 @@ func BenchmarkPreparedInsertSelect(b *testing.B) {
 	check(err)
 	check(my.Close())
 }
+
+// Defaults test
+func TestDefaultPort(t *testing.T) {
+	my = New("tcp", "", "127.0.0.1", user, passwd)
+	checkErr(t, my.Connect(), nil)
+}


### PR DESCRIPTION
Hi ziutek,

Most other mysql libraries I have used default the port to 3306 when it is not specified and I thought it would be useful if this package worked that way as well.  

This pull request checks for a tcp protocol and will append the default port of none is specified before 
the call to TcpDial. 

Thank you for building this great package!  
