### PR TITLE
Allow any driver instance to register on-connect queries

### DIFF
--- a/godrv/driver.go
+++ b/godrv/driver.go
@@ -386,7 +386,11 @@ var d = Driver{proto: "tcp", raddr: "127.0.0.1:3306"}
 // Registers initialisation commands.
 // This is workaround, see http://codereview.appspot.com/5706047
 func Register(query string) {
-	d.initCmds = append(d.initCmds, query)
+	d.Register(query)
+}
+
+func (drv *Driver) Register(query string) {
+	drv.initCmds = append(d.initCmds, query)
 }
 
 func init() {


### PR DESCRIPTION
I'm writing a DB instrumentation library which needs to manipulate go drivers, so I can't use the builtin one.

This change lets me register commands to any driver instance, rather than just the builtin / default one.
