### PR TITLE
Fix encodeNonzeroTime to encode timestamps correctly.

### DIFF
--- a/native/codecs.go
+++ b/native/codecs.go
@@ -373,11 +373,12 @@ func (pr *pktReader) readTime() time.Time {
 	return time.Date(y, time.Month(mon), d, h, m, s, n, time.Local)
 }
 
+// See http://dev.mysql.com/doc/internals/en/binary-protocol-value.html#packet-ProtocolBinary::MYSQL_TYPE_TIMESTAMP
 func encodeNonzeroTime(buf []byte, y int16, mon, d, h, m, s byte, n uint32) int {
 	buf[0] = 0
 	switch {
 	case n != 0:
-		EncodeU32(buf[7:12], n)
+		EncodeU32(buf[8:12], n / 1000) // microseconds
 		buf[0] += 4
 		fallthrough
 	case s != 0 || m != 0 || h != 0:


### PR DESCRIPTION
This is a fix for the datetime binary encoding.  I was inserting timestamps and most of the time they were showing up in MySQL as  "0000-00-00 00:00:00, even though the values definitely contained valid timestamps. Sometimes, the timestamps did insert correctly, though.

I narrowed it down to an encoding problem with the microseconds field.

Also, it seems like may be related to issue #74? @ex-troll can you give this a try.
