### PR TITLE
godrv: Get a nil interface{} if a column field of type DATETIME is null

### DIFF
--- a/godrv/driver.go
+++ b/godrv/driver.go
@@ -256,10 +256,12 @@ func (r *rowsRes) Next(dest []driver.Value) error {
 		if r.simpleQuery == textQuery {
 			// workaround for time.Time from text queries
 			for i, f := range r.my.Fields() {
-				switch f.Type {
-				case native.MYSQL_TYPE_TIMESTAMP, native.MYSQL_TYPE_DATETIME,
-					native.MYSQL_TYPE_DATE, native.MYSQL_TYPE_NEWDATE:
-					r.row[i] = r.row.ForceLocaltime(i)
+				if r.row[i] != nil {
+					switch f.Type {
+					case native.MYSQL_TYPE_TIMESTAMP, native.MYSQL_TYPE_DATETIME,
+						native.MYSQL_TYPE_DATE, native.MYSQL_TYPE_NEWDATE:
+						r.row[i] = r.row.ForceLocaltime(i)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Previously, if you had a nil interface{} or *time.Time as a scan destiny, and your date/time result was null, godrv created a zero time.Time. This is inconsistent with both mymysql/native and database/sql behavior, and makes impossible to tell a zero value from a null value.

With this little change null field -> time.Time still makes a zero time.Time, but null field -> *time.Time, interface{} will result in a nil pointer/interface value.
