### PR TITLE
Add import information to Example 7.

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,13 @@ This is the improved code of the previous example:
 
 ### Example 7 - use database/sql with mymysql driver
 
+    import (
+        "database/sql"
+        _"github.com/ziutek/mymysql/godrv"
+    )
+
+	// [...]
+
 	// Open new connection. The uri need to have the following syntax:
 	//
 	//   [PROTOCOL_SPECFIIC*]DBNAME/USER/PASSWD


### PR DESCRIPTION
It wasn't totally clear in the example provided on the README what to import to use the mymysql godrv with the database/sql package.  This diff makes that explicit.  
