### PR TITLE
Add support for fmt.Stringer as a bindable type

### DIFF
--- a/native/bind_test.go
+++ b/native/bind_test.go
@@ -11,9 +11,18 @@ import (
 	"time"
 )
 
+type stringer struct {
+	val string
+}
+
+func (s stringer) String() string {
+	return s.val
+}
+
 var (
 	Bytes  = []byte("Ala ma Kota!")
 	String = "ssss" //"A kot ma Alę!"
+	Stringer = stringer{String}
 	blob   = mysql.Blob{1, 2, 3}
 	dateT  = time.Date(2010, 12, 30, 17, 21, 01, 0, time.Local)
 	tstamp = mysql.Timestamp{dateT.Add(1e9)}
@@ -23,6 +32,7 @@ var (
 
 	pBytes  *[]byte
 	pString *string
+	pStringer *stringer
 	pBlob   *mysql.Blob
 	pDateT  *time.Time
 	pTstamp *mysql.Timestamp
@@ -92,6 +102,7 @@ var bindTests = []BindTest{
 
 	BindTest{Bytes, MYSQL_TYPE_VAR_STRING, -1},
 	BindTest{String, MYSQL_TYPE_STRING, -1},
+	BindTest{Stringer, MYSQL_TYPE_STRING, -1},
 	BindTest{blob, MYSQL_TYPE_BLOB, -1},
 	BindTest{dateT, MYSQL_TYPE_DATETIME, -1},
 	BindTest{tstamp, MYSQL_TYPE_TIMESTAMP, -1},
@@ -101,6 +112,7 @@ var bindTests = []BindTest{
 
 	BindTest{&Bytes, MYSQL_TYPE_VAR_STRING, -1},
 	BindTest{&String, MYSQL_TYPE_STRING, -1},
+	BindTest{&Stringer, MYSQL_TYPE_STRING, -1},
 	BindTest{&blob, MYSQL_TYPE_BLOB, -1},
 	BindTest{&dateT, MYSQL_TYPE_DATETIME, -1},
 	BindTest{&tstamp, MYSQL_TYPE_TIMESTAMP, -1},
@@ -109,6 +121,7 @@ var bindTests = []BindTest{
 
 	BindTest{pBytes, MYSQL_TYPE_VAR_STRING, -1},
 	BindTest{pString, MYSQL_TYPE_STRING, -1},
+	BindTest{pStringer, MYSQL_TYPE_STRING, -1},
 	BindTest{pBlob, MYSQL_TYPE_BLOB, -1},
 	BindTest{pDateT, MYSQL_TYPE_DATETIME, -1},
 	BindTest{pTstamp, MYSQL_TYPE_TIMESTAMP, -1},

--- a/native/mysql.go
+++ b/native/mysql.go
@@ -508,8 +508,8 @@ func (my *Conn) Prepare(sql string) (mysql.Stmt, error) {
 // params may be a parameter list (slice), a struct or a pointer to the struct.
 // A struct field can by value or pointer to value. A parameter (slice element)
 // can be value, pointer to value or pointer to pointer to value.
-// Values may be of the folowind types: intXX, uintXX, floatXX, bool, []byte,
-// Blob, string, Time, Date, Time, Timestamp, Raw.
+// Values may be of the folowing types: intXX, uintXX, floatXX, bool, []byte,
+// Blob, string, Time, Date, Time, Timestamp, Raw, fmt.Stringer.
 func (stmt *Stmt) Bind(params ...interface{}) {
 	stmt.rebind = true
 


### PR DESCRIPTION
Allow implementations of fmt.Stringer to be passed as arguments to stmt.Bind() and stmt.Exec()