### PR TITLE
add the default mysql port if it is not specified

### DIFF
--- a/godrv/driver.go
+++ b/godrv/driver.go
@@ -323,6 +323,17 @@ func (d *Driver) Open(uri string) (driver.Conn, error) {
 		cfg.proto = p[0]
 		options := strings.Split(p[1], ",")
 		cfg.raddr = options[0]
+
+		_, _, err := net.SplitHostPort(cfg.raddr)
+		if err != nil {
+			if strings.HasPrefix(err.Error(), "missing port in address") {
+				cfg.raddr = cfg.raddr + ":3306"
+			} else {
+				// unable to split address and port for some other reason
+				return nil, err
+			}
+		}
+
 		for _, o := range options[1:] {
 			kv := strings.SplitN(o, "=", 2)
 			var k, v string


### PR DESCRIPTION
If a port is not specified in the connect string, the default mysql port should be added