### PR TITLE
Enlarge pktReader buf for larger dates

### DIFF
--- a/native/packet.go
+++ b/native/packet.go
@@ -12,7 +12,7 @@ type pktReader struct {
 	seq    *byte
 	remain int
 	last   bool
-	buf    [8]byte
+	buf    [12]byte
 	ibuf   [3]byte
 }
 


### PR DESCRIPTION
Mysql timestamps and durations can be up to 11 and 12 bytes, respectively. Reading them causes slice bounds issues when reading them in codecs.go.