### PR TITLE
mysql 5.0/5.1 auth compatible bug fix

### DIFF
--- a/native/init.go
+++ b/native/init.go
@@ -108,6 +108,8 @@ func (my *Conn) auth() {
 	// write plugin name
 	if my.plugin != "" {
 		pw.writeNTB([]byte(my.plugin))
+	} else {
+		pw.writeNTB([]byte("mysql_native_password"))
 	}
 	return
 }
@@ -130,6 +132,8 @@ func (my *Conn) authResponse() {
 			scrPasswd = encryptedSHA256Passwd(my.passwd, my.info.scramble[:])
 		case "mysql_old_password":
 			scrPasswd = encryptedOldPassword(my.passwd, my.info.scramble[:])
+			// append \0 after old_password
+			scrPasswd = append(scrPasswd, 0)
 		case "sha256_password":
 			// request public key from server
 			scrPasswd = []byte{1}


### PR DESCRIPTION
If MySQL version is 5.1.x or old than it, no auth plugin name will be given. It will cause an EOF error.
Append `mysql_native_password` by default can fix this problem.

In this commit also fix a regression bug with mysql_old_password, old_password scramble loses a zero ending byte in authResponse for message ending.

test with docker & example/simple/simple.go
```bash
docker run --rm -d --name mysql-5.1.73 -p 3306:3306 -e MYSQL_ROOT_PASSWORD=password vsamov/mysql-5.1.73
```